### PR TITLE
fix response bodies and endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -83,9 +83,10 @@ func (cli *Client) GetDocument(docID string) (*Document, error) {
 		}
 	}
 	return &Document{
-		ID:          *resp.Payload.ID,
-		Content:     *resp.Payload.Content,
-		Extension:   *resp.Payload.Extension,
-		DateCreated: *resp.Payload.DateCreated,
+		ID:        *resp.Payload.ID,
+		Content:   *resp.Payload.Content,
+		Extension: *resp.Payload.Extension,
+		UpdatedAt: *resp.Payload.UpdatedAt,
+		CreatedAt: *resp.Payload.CreatedAt,
 	}, nil
 }

--- a/client.go
+++ b/client.go
@@ -38,7 +38,7 @@ func (cli *Client) makeRequest(req *http.Request) (*Response, error) {
 // CreateDocument allows you to create a new document on the Spacebin. The only parameter is a *CreateDocumentOpts.
 // The return value of this method is a *HashDocument.
 func (cli *Client) CreateDocument(opts *CreateDocumentOpts) (*HashDocument, error) {
-	url := fmt.Sprintf("%s/api/v1/documents/", cli.Host)
+	url := fmt.Sprintf("%s/api/v1/documents", cli.Host)
 	j, err := opts.Marshal()
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -38,7 +38,7 @@ func (cli *Client) makeRequest(req *http.Request) (*Response, error) {
 // CreateDocument allows you to create a new document on the Spacebin. The only parameter is a *CreateDocumentOpts.
 // The return value of this method is a *HashDocument.
 func (cli *Client) CreateDocument(opts *CreateDocumentOpts) (*HashDocument, error) {
-	url := fmt.Sprintf("%s/api/v1/document", cli.Host)
+	url := fmt.Sprintf("%s/api/v1/documents/", cli.Host)
 	j, err := opts.Marshal()
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (cli *Client) CreateDocument(opts *CreateDocumentOpts) (*HashDocument, erro
 // GetDocument allows you to retrieve a document from the Spacebin. The only parameter is a string, the document ID.
 // The return value of this method is a *Document.
 func (cli *Client) GetDocument(docID string) (*Document, error) {
-	url := fmt.Sprintf("%s/api/v1/document/%s", cli.Host, docID)
+	url := fmt.Sprintf("%s/api/v1/documents/%s", cli.Host, docID)
 	req, err := http.NewRequest("GET", url, bytes.NewBuffer([]byte{}))
 	if err != nil {
 		return nil, err
@@ -88,22 +88,4 @@ func (cli *Client) GetDocument(docID string) (*Document, error) {
 		Extension:   *resp.Payload.Extension,
 		DateCreated: *resp.Payload.DateCreated,
 	}, nil
-}
-
-// DocumentExists allows you to check if a document exists on the Spacebin. The only parameter is a string,  the document ID.
-// The return value of this method is a bool, designating if the document exists or not.
-func (cli *Client) DocumentExists(docID string) (bool, error) {
-	url := fmt.Sprintf("%s/api/v1/document/%s/verify", cli.Host, docID)
-	req, err := http.NewRequest("GET", url, bytes.NewBuffer([]byte{}))
-	if err != nil {
-		return false, err
-	}
-	resp, err := cli.makeRequest(req)
-	if err != nil {
-		return false, err
-	}
-	if resp.Status != 200 && resp.Status != 404 {
-		return false, fmt.Errorf("%s", resp.Error)
-	}
-	return *resp.Payload.Exists, nil
 }

--- a/opts.go
+++ b/opts.go
@@ -10,7 +10,7 @@ func NewCreateDocumentOpts(content string) *CreateDocumentOpts {
 	}
 }
 
-// SetExtension sets the content for the *CreateDocumentOpts.
+// SetContent sets the content for the *CreateDocumentOpts.
 // It returns the *CreateDocumentOpts
 func (opts *CreateDocumentOpts) SetContent(content string) *CreateDocumentOpts {
 	opts.Content = content

--- a/types.go
+++ b/types.go
@@ -18,19 +18,21 @@ func (r *Response) Marshal() ([]byte, error) {
 
 // A Spacebin API response
 type Response struct {
-	Error   string  `json:"error,omitempty"`   // The error, if one occurred
-	Payload Payload `json:"payload"` // The main body of the response
-	Status  int64   `json:"status"`  // The status code of the response
+	Error   string  `json:"error,omitempty"` // The error, if one occurred
+	Payload Payload `json:"payload"`         // The main body of the response
+	Status  int64   `json:"status"`          // The status code of the response
 }
 
 // The main body of the response
 type Payload struct {
-	Content     *string `json:"content,omitempty"`    // The document content
-	ContentHash *string `json:"contentHash,omitempty"`// The hash of the document content
-	DateCreated *string `json:"dateCreated,omitempty"`// The date & time of which the document was created
-	Extension   *string `json:"extension,omitempty"`  // The file extension of the document
-	ID          *string `json:"id,omitempty"`         // The document ID
-	Exists      *bool   `json:"exists,omitempty"`     // If the document exists or not
+	Content     *string `json:"content,omitempty"`     // The document content
+	ContentHash *string `json:"contentHash,omitempty"` // The hash of the document content
+	DateCreated *string `json:"dateCreated,omitempty"` // The date & time of which the document was created
+	Extension   *string `json:"extension,omitempty"`   // The file extension of the document
+	ID          *string `json:"id,omitempty"`          // The document ID
+	Exists      *bool   `json:"exists,omitempty"`      // If the document exists or not
+	CreatedAt   *int    `json:"created_at,omitempty"`  // The time the document was created
+	UpdatedAt   *int    `json:"updated_at,omitempty"`  // The time the document was last modified/updated
 }
 
 // Represents the Spacebin API Client
@@ -40,7 +42,7 @@ type Client struct {
 
 // Information needed to create a document
 type CreateDocumentOpts struct {
-	Content   string `json:"content"` 	// The content of the document
+	Content   string `json:"content"`   // The content of the document
 	Extension string `json:"extension"` // The file extension of the document
 }
 
@@ -51,15 +53,15 @@ func (opts *CreateDocumentOpts) Marshal() ([]byte, error) {
 
 // Returned when POSTing a document
 type HashDocument struct {
-	ID 			string // The document ID
+	ID          string // The document ID
 	ContentHash string // The hash of the document content
-	Extension 	string // The file extension of the document
+	Extension   string // The file extension of the document
 }
 
 // Returned when GETting a document
 type Document struct {
-	ID 			string // The document ID
-	Content 	string // The document content
-	Extension 	string // The file extension of the document
+	ID          string // The document ID
+	Content     string // The document content
+	Extension   string // The file extension of the document
 	DateCreated string // The date & time of which the document was created
 }

--- a/types.go
+++ b/types.go
@@ -59,8 +59,9 @@ type HashDocument struct {
 
 // Returned when GETting a document
 type Document struct {
-	ID          string // The document ID
-	Content     string // The document content
-	Extension   string // The file extension of the document
-	DateCreated string // The date & time of which the document was created
+	ID        string // The document ID
+	Content   string // The document content
+	Extension string // The file extension of the document
+	CreatedAt int    // The time the document was created
+	UpdatedAt int    // The time the document was last modified
 }

--- a/types.go
+++ b/types.go
@@ -25,14 +25,13 @@ type Response struct {
 
 // The main body of the response
 type Payload struct {
-	Content     *string `json:"content,omitempty"`     // The document content
-	ContentHash *string `json:"contentHash,omitempty"` // The hash of the document content
-	DateCreated *string `json:"dateCreated,omitempty"` // The date & time of which the document was created
-	Extension   *string `json:"extension,omitempty"`   // The file extension of the document
-	ID          *string `json:"id,omitempty"`          // The document ID
-	Exists      *bool   `json:"exists,omitempty"`      // If the document exists or not
-	CreatedAt   *int    `json:"created_at,omitempty"`  // The time the document was created
-	UpdatedAt   *int    `json:"updated_at,omitempty"`  // The time the document was last modified/updated
+	Content     *string `json:"content,omitempty"`      // The document content
+	ContentHash *string `json:"content_hash,omitempty"` // The hash of the document content
+	Extension   *string `json:"extension,omitempty"`    // The file extension of the document
+	ID          *string `json:"id,omitempty"`           // The document ID
+	Exists      *bool   `json:"exists,omitempty"`       // If the document exists or not
+	CreatedAt   *int    `json:"created_at,omitempty"`   // The time the document was created
+	UpdatedAt   *int    `json:"updated_at,omitempty"`   // The time the document was last modified/updated
 }
 
 // Represents the Spacebin API Client


### PR DESCRIPTION
The API was recently updated that changed:

* The location of the document endpoints.
* The responses sent back by the server.
* Removes the verify endpoints. **(BREAKING)**

This PR updates `gospacebin` to work with these changes.

I checked the repositories of the projects currently using `gospacebin` (`greatgodapollo/lunar`, `spacebin-org/pulsar`), and none of them used the `DocumentExists` method so I don't think removing it will cause any problems.